### PR TITLE
Added WAFs for each gateway

### DIFF
--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -152,7 +152,7 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
 
-  ZendeskWebhookWafAcl:
+  ZendeskWebhookApiWafAcl:
     Type: AWS::WAFv2::WebACL
     Properties:
       DefaultAction:
@@ -160,7 +160,7 @@ Resources:
       Scope: REGIONAL
       VisibilityConfig:
         CloudWatchMetricsEnabled: true
-        MetricName: TxmaWafMetric
+        MetricName: ZendeskWebhookApiWafMetric
         SampledRequestsEnabled: true
       Rules:
         - Name: AwsManagedRulesCommonRuleSet
@@ -175,7 +175,7 @@ Resources:
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesCommonRuleSetMetric
+            MetricName: ZendeskWebhookApiWafCommonRuleSetMetric
         - Name: AWSManagedRulesKnownBadInputsRuleSet
           Priority: 1
           Statement:
@@ -186,7 +186,7 @@ Resources:
             None: {}
           VisibilityConfig:
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+            MetricName: ZendeskWebhookApiWafKnownBadInputsRuleSetMetric
             SampledRequestsEnabled: true
         - Name: AWSManagedRulesAmazonIpReputationList
           Priority: 2
@@ -198,7 +198,7 @@ Resources:
             None: {}
           VisibilityConfig:
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesAmazonIpReputationListMetric
+            MetricName: ZendeskWebhookApiWafIpReputationListMetric
             SampledRequestsEnabled: true
 
   BatchJobManifestBucketArnParameter:
@@ -271,9 +271,9 @@ Resources:
       Type: String
       Value: !Ref QueryRequestTable
 
-  ZendeskWebhookWafAclArnParameter:
+  ZendeskWebhookApiWafAclArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: ZendeskWebhookWafAclArn
+      Name: ZendeskWebhookApiWafAclArn
       Type: String
-      Value: !GetAtt ZendeskWebhookWafAcl.Arn
+      Value: !GetAtt ZendeskWebhookApiWafAcl.Arn

--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -152,6 +152,55 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
 
+  ZendeskWebhookWafAcl:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      DefaultAction:
+        Allow: {}
+      Scope: REGIONAL
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: TxmaWafMetric
+        SampledRequestsEnabled: true
+      Rules:
+        - Name: AwsManagedRulesCommonRuleSet
+          Priority: 0
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              ExcludedRules: []
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesCommonRuleSetMetric
+        - Name: AWSManagedRulesKnownBadInputsRuleSet
+          Priority: 1
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+            SampledRequestsEnabled: true
+        - Name: AWSManagedRulesAmazonIpReputationList
+          Priority: 2
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesAmazonIpReputationListMetric
+            SampledRequestsEnabled: true
+
   BatchJobManifestBucketArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -221,3 +270,10 @@ Resources:
       Name: QueryRequestTableName
       Type: String
       Value: !Ref QueryRequestTable
+
+  ZendeskWebhookWafAclArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: ZendeskWebhookWafAclArn
+      Type: String
+      Value: !GetAtt ZendeskWebhookWafAcl.Arn

--- a/query-results/template.yaml
+++ b/query-results/template.yaml
@@ -67,6 +67,55 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
 
+  SecureFraudApiWafAcl:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      DefaultAction:
+        Allow: {}
+      Scope: REGIONAL
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: TxmaWafMetric
+        SampledRequestsEnabled: true
+      Rules:
+        - Name: AwsManagedRulesCommonRuleSet
+          Priority: 0
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+              ExcludedRules: []
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesCommonRuleSetMetric
+        - Name: AWSManagedRulesKnownBadInputsRuleSet
+          Priority: 1
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+            SampledRequestsEnabled: true
+        - Name: AWSManagedRulesAmazonIpReputationList
+          Priority: 2
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+          OverrideAction:
+            None: {}
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedRulesAmazonIpReputationListMetric
+            SampledRequestsEnabled: true
+
   QueryResultsBucketArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -94,6 +143,13 @@ Resources:
       Name: SecureFraudSiteDataTableName
       Type: String
       Value: !Ref SecureFraudSiteDataTable
+
+  SecureFraudApiWafAclArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: SecureFraudApiWafAclArn
+      Type: String
+      Value: !GetAtt SecureFraudApiWafAcl.Arn
 
 Outputs:
   QueryResultsBucketName:

--- a/query-results/template.yaml
+++ b/query-results/template.yaml
@@ -95,7 +95,7 @@ Resources:
       Scope: REGIONAL
       VisibilityConfig:
         CloudWatchMetricsEnabled: true
-        MetricName: TxmaWafMetric
+        MetricName: SecureFraudApiWafMetric
         SampledRequestsEnabled: true
       Rules:
         - Name: AwsManagedRulesCommonRuleSet
@@ -110,7 +110,7 @@ Resources:
           VisibilityConfig:
             SampledRequestsEnabled: true
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesCommonRuleSetMetric
+            MetricName: SecureFraudApiCommonRuleSetMetric
         - Name: AWSManagedRulesKnownBadInputsRuleSet
           Priority: 1
           Statement:
@@ -121,7 +121,7 @@ Resources:
             None: {}
           VisibilityConfig:
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesKnownBadInputsRuleSetMetric
+            MetricName: SecureFraudApiKnownBadInputsRuleSetMetric
             SampledRequestsEnabled: true
         - Name: AWSManagedRulesAmazonIpReputationList
           Priority: 2
@@ -133,7 +133,7 @@ Resources:
             None: {}
           VisibilityConfig:
             CloudWatchMetricsEnabled: true
-            MetricName: AWSManagedRulesAmazonIpReputationListMetric
+            MetricName: SecureFraudApiIpReputationListMetric
             SampledRequestsEnabled: true
 
   QueryResultsBucketArnParameter:


### PR DESCRIPTION
- Added an ACL for each API gateway. Added 1 per gateway since we may want to add extra rules to each e.g. IP restrictions can be done at the WAF level (and are easier to update than what we currently have at a policy level)