### PR TITLE
Add dns-records stack for query results account

### DIFF
--- a/.github/workflows/package-dns-records-query-results.yaml
+++ b/.github/workflows/package-dns-records-query-results.yaml
@@ -1,0 +1,90 @@
+name: Package DNS records for Query Results account
+
+on:
+  push:
+    paths:
+      - dns-records-query-results/**
+  workflow_dispatch: {}
+
+env:
+  AWS_REGION: eu-west-2
+
+jobs:
+  validate:
+    name: Validate template
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dns-records-query-results
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS Validate role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.GH_ACTIONS_VALIDATE_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS }}
+      - name: Validate SAM template
+        if: always()
+        run: sam validate
+      - name: Run Checkov on SAM template
+        if: always()
+        uses: bridgecrewio/checkov-action@master
+        with:
+          file: template.yaml
+          quiet: true
+          framework: cloudformation
+      - name: Upload template artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dns-records-query-results-sam-template
+          path: |
+            dns-records-query-results/template.yaml
+
+  package:
+    strategy:
+      matrix:
+        target: [QUERY_RESULTS_BUILD]
+        include:
+          - target: QUERY_RESULTS_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_RECORDS_QUERY_RESULTS
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS
+            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
+    name: Package template
+    if: github.ref == 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dns-records-query-results-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Package SAM app
+        uses: alphagov/di-devplatform-upload-action@v2
+        with:
+          artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+          signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}
+          working-directory: '.'

--- a/dns-records-query-results/template.yaml
+++ b/dns-records-query-results/template.yaml
@@ -1,0 +1,63 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Creates the necessary DNS zones and records for the query results account
+Parameters:
+  Environment:
+    Description: The environment type
+    Type: String
+    AllowedValues:
+      - build
+      - staging
+      - integration
+      - production
+
+Mappings:
+  Environment:
+    build:
+      ResultsApiDomainName: !Sub results.transaction.build.account.gov.uk
+    staging:
+      ResultsApiDomainName: !Sub results.transaction.staging.account.gov.uk
+    integration:
+      ResultsApiDomainName: !Sub results.transaction.integration.account.gov.uk
+    production:
+      ResultsApiDomainName: results.transaction.account.gov.uk
+
+Resources:
+  ResultsPublicHostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !FindInMap [Environment, !Ref Environment, ResultsApiDomainName]
+
+  ResultsApiCertificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName:
+        !FindInMap [Environment, !Ref Environment, ResultsApiDomainName]
+      DomainValidationOptions:
+        - DomainName:
+            !FindInMap [Environment, !Ref Environment, ResultsApiDomainName]
+          HostedZoneId: !Ref ResultsApiPublicHostedZone
+      ValidationMethod: DNS
+
+  ResultsApiDomainName:
+    Type: AWS::ApiGateway::DomainName
+    Properties:
+      DomainName:
+        !FindInMap [Environment, !Ref Environment, ResultsApiDomainName]
+      EndpointConfiguration:
+        Types:
+          - REGIONAL
+      RegionalCertificateArn: !Ref ResultsApiCertificate
+      SecurityPolicy: TLS_1_2
+
+  ResultsApiDomainNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: ResultsApiDomainName
+      Type: String
+      Value: !Ref ResultsApiDomainName
+
+Outputs:
+  ResultsPublicHostedZoneNameServers:
+    Value: !Join [',', !GetAtt ResultsPublicHostedZone.NameServers]


### PR DESCRIPTION
Adds a Route 53 Hosted Zone, API Gateway Domain name, and certificate.

DNS delegation is done in the audit account, so we need to output the NameServers in order to use the value to create the DNS delegation records in the audit account.