### PR TITLE
Check changeset before merge

### DIFF
--- a/.github/workflows/delete-feature-branch.yaml
+++ b/.github/workflows/delete-feature-branch.yaml
@@ -1,0 +1,45 @@
+name: Delete feature branch stack
+
+on:
+  delete:
+    branches-ignore:
+      - main
+
+env:
+  AWS_REGION: eu-west-2
+
+jobs:
+  delete-feature:
+    name: Delete feature branch
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume the dev account deployment role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.GH_ACTIONS_DEV_DEPLOY_ROLE_ARN }}
+      - name: Delete feature branch stack
+        env:
+          FEATURE_BRANCH_NAME: ${{ github.event.ref }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam delete \
+            --stack-name ${stack_name} \
+            --region ${AWS_REGION} \
+            --no-prompts

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -84,7 +83,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -147,7 +145,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -49,6 +50,65 @@ jobs:
           name: core-sam-template
           path: |
             core/template.yaml
+
+  deploy-dry-run:
+    strategy:
+      matrix:
+        target: [AUDIT_DEV, QUERY_RESULTS_DEV, AUDIT_BUILD, QUERY_RESULTS_BUILD]
+        include:
+          - target: AUDIT_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_CORE_AUDIT_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_CORE_AUDIT_DEV
+          - target: QUERY_RESULTS_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_CORE_QUERY_RESULTS_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_CORE_QUERY_RESULTS_DEV
+          - target: AUDIT_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_CORE_AUDIT_BUILD
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_CORE_AUDIT_BUILD
+          - target: QUERY_RESULTS_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_CORE_QUERY_RESULTS_BUILD
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_CORE_QUERY_RESULTS_BUILD
+    name: Create changeset
+    if: github.ref != 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: core-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
 
   package:
     strategy:
@@ -87,6 +147,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -78,7 +77,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -133,7 +131,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -49,6 +50,59 @@ jobs:
           name: data-analysis-sam-template
           path: |
             data-analysis/template.yaml
+
+  deploy-dry-run:
+    strategy:
+      matrix:
+        target: [AUDIT_DEV, AUDIT_BUILD]
+        include:
+          - target: AUDIT_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DATA_ANALYSIS_AUDIT_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DATA_ANALYSIS_AUDIT_DEV
+          - target: AUDIT_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DATA_ANALYSIS_AUDIT_BUILD
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DATA_ANALYSIS_AUDIT_BUILD
+    name: Create changeset
+    if: github.ref != 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: data-analysis-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
 
   package:
     strategy:
@@ -79,6 +133,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -89,7 +88,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -144,7 +142,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -61,6 +62,59 @@ jobs:
             dev-tools/dist/
             dev-tools/template.yaml
 
+  deploy-dry-run:
+    strategy:
+      matrix:
+        target: [AUDIT_DEV, QUERY_RESULTS_DEV]
+        include:
+          - target: AUDIT_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DEV_TOOLS_AUDIT_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DEV_TOOLS_AUDIT_DEV
+          - target: QUERY_RESULTS_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DEV_TOOLS_QUERY_RESULTS_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DEV_TOOLS_QUERY_RESULTS_DEV
+    name: Create changeset
+    if: github.ref != 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dev-tools-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
+
   package:
     strategy:
       matrix:
@@ -90,6 +144,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dns-records-query-results.yaml
+++ b/.github/workflows/package-dns-records-query-results.yaml
@@ -59,7 +59,6 @@ jobs:
           - target: QUERY_RESULTS_BUILD
             ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_RECORDS_QUERY_RESULTS
             GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS
-            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
     name: Create changeset
     if: github.ref != 'refs/heads/main'
     needs: [validate]

--- a/.github/workflows/package-dns-records-query-results.yaml
+++ b/.github/workflows/package-dns-records-query-results.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -75,7 +74,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -126,7 +124,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dns-records-query-results.yaml
+++ b/.github/workflows/package-dns-records-query-results.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -50,7 +51,7 @@ jobs:
           path: |
             dns-records-query-results/template.yaml
 
-  package:
+  create-changeset:
     strategy:
       matrix:
         target: [QUERY_RESULTS_BUILD]
@@ -59,8 +60,7 @@ jobs:
             ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_RECORDS_QUERY_RESULTS
             GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS
             SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
-    name: Package template
-    if: github.ref == 'refs/heads/main'
+    name: Create changeset
     needs: [validate]
     permissions:
       id-token: write
@@ -75,6 +75,58 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
+
+  package:
+    strategy:
+      matrix:
+        target: [QUERY_RESULTS_BUILD]
+        include:
+          - target: QUERY_RESULTS_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_RECORDS_QUERY_RESULTS
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS
+            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
+    name: Package template
+    if: github.ref == 'refs/heads/main'
+    needs: [validate, create-changeset]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dns-records-query-results-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dns-records-query-results.yaml
+++ b/.github/workflows/package-dns-records-query-results.yaml
@@ -51,7 +51,7 @@ jobs:
           path: |
             dns-records-query-results/template.yaml
 
-  create-changeset:
+  deploy-dry-run:
     strategy:
       matrix:
         target: [QUERY_RESULTS_BUILD]
@@ -61,6 +61,7 @@ jobs:
             GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_RECORDS_QUERY_RESULTS
             SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
     name: Create changeset
+    if: github.ref != 'refs/heads/main'
     needs: [validate]
     permissions:
       id-token: write
@@ -112,7 +113,7 @@ jobs:
             SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
     name: Package template
     if: github.ref == 'refs/heads/main'
-    needs: [validate, create-changeset]
+    needs: [validate]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/package-dns-zones.yaml
+++ b/.github/workflows/package-dns-zones.yaml
@@ -1,4 +1,4 @@
-name: Package dns zones
+name: Package DNS zones
 
 on:
   push:
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -50,19 +51,65 @@ jobs:
           path: |
             dns-zones/template.yaml
 
-  package:
+  deploy-dry-run:
     strategy:
       matrix:
-        target: [AUDIT_BUILD, QUERY_RESULTS_BUILD]
+        target: [AUDIT_BUILD]
         include:
           - target: AUDIT_BUILD
             ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_ZONES_AUDIT
             GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_ZONES_AUDIT
-            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_AUDIT_BUILD
-          - target: QUERY_RESULTS_BUILD
-            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_ZONES_QUERY_RESULTS
-            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_ZONES_QUERY_RESULTS
-            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_QUERY_RESULTS_BUILD
+    name: Create changeset
+    if: github.ref != 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dns-zones-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
+
+  package:
+    strategy:
+      matrix:
+        target: [AUDIT_BUILD]
+        include:
+          - target: AUDIT_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_DNS_ZONES_AUDIT
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_DNS_ZONES_AUDIT
+            SIGNING_PROFILE_SECRET: SIGNING_PROFILE_NAME_AUDIT_BUILD
     name: Package template
     if: github.ref == 'refs/heads/main'
     needs: [validate]
@@ -79,6 +126,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-dns-zones.yaml
+++ b/.github/workflows/package-dns-zones.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -75,7 +74,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -126,7 +124,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -78,7 +77,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role
@@ -133,7 +131,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
-          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS Validate role
@@ -49,6 +50,59 @@ jobs:
           name: query-results-sam-template
           path: |
             query-results/template.yaml
+
+  deploy-dry-run:
+    strategy:
+      matrix:
+        target: [QUERY_RESULTS_DEV, QUERY_RESULTS_BUILD]
+        include:
+          - target: QUERY_RESULTS_DEV
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_QUERY_RESULTS_DEV
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_QUERY_RESULTS_DEV
+          - target: QUERY_RESULTS_BUILD
+            ARTIFACT_BUCKET_NAME_SECRET: ARTIFACT_BUCKET_NAME_QUERY_RESULTS_BUILD
+            GH_ACTIONS_ROLE_ARN_SECRET: GH_ACTIONS_ROLE_ARN_QUERY_RESULTS_BUILD
+    name: Create changeset
+    if: github.ref != 'refs/heads/main'
+    needs: [validate]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: query-results-sam-template
+      - name: Setup Python 3.8
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.8'
+          cache: pip
+      - name: Setup SAM CLI
+        uses: aws-actions/setup-sam@v2
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
+      - name: Create changeset
+        env:
+          BRANCH_NAME: ${{ github.event.ref }}
+          S3_BUCKET: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
+        run: |
+          stack_name=$(
+            echo ${BRANCH_NAME##*/} | \
+            tr -cd '[a-zA-Z0-9-]' | \
+            tr '[:upper:]' '[:lower:]' | \
+            cut -c -32
+          )
+
+          sam deploy \
+            --stack-name ${stack_name} \
+            --no-execute-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket ${S3_BUCKET}
 
   package:
     strategy:
@@ -79,6 +133,7 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: '3.8'
+          cache: pip
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v2
       - name: Assume AWS role


### PR DESCRIPTION
Because SAM validate doesn't actually pick up all that much in the way of errors, have added a job which does a dry-run deployment. We can run this before merge to check that the deployment at least creates a changeset. This should catch errors like unresolved SSM parameters, reference errors in the template etc.

Added a delete feature stack workflow so that we don't end up with a load of stacks everywhere with status `REVIEW_IN_PROGRESS`