### PR TITLE
Lock down QueryCompleteQueue resources to specific lambda role

### DIFF
--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -13,6 +13,10 @@ Parameters:
       - integration
       - production
 
+Conditions:
+  LockCrossAccountPermissionsToLambdaRoles:
+    !Not [!Equals [!Ref Environment, dev]]
+
 Resources:
   BatchJobManifestBucket:
     Type: AWS::S3::Bucket
@@ -397,10 +401,18 @@ Resources:
           - Sid: Enable Decrypt access for Query Results account generate download Lambda
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-build-generate-download-role'
+              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
             Action:
               - kms:Decrypt
             Resource: '*'
+            Condition:
+              StringEquals:
+                'aws:principalArn':
+                  !If [
+                    LockCrossAccountPermissionsToLambdaRoles,
+                    'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role',
+                    '*'
+                  ]
           - Sid: Allow AWS Lambda access
             Effect: Allow
             Principal:
@@ -442,8 +454,15 @@ Resources:
             Effect: 'Allow'
             Resource: !GetAtt QueryCompletedQueue.Arn
             Principal:
-              AWS:
-                - !Sub 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-build-generate-download-role'
+              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+            Condition:
+              StringEquals:
+                'aws:principalArn':
+                  !If [
+                    LockCrossAccountPermissionsToLambdaRoles,
+                    'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role',
+                    '*'
+                  ]
 
   QueryCompletedDeadLetterQueue:
     Type: AWS::SQS::Queue

--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -398,6 +398,9 @@ Resources:
             Action:
               - kms:*
             Resource: '*'
+          - !If
+          - LockCrossAccountPermissionsToLambdaRoles
+          # If we are in a non-dev environment so know the lambda role name
           - Sid: Enable Decrypt access for Query Results account generate download Lambda
             Effect: Allow
             Principal:
@@ -407,12 +410,15 @@ Resources:
             Resource: '*'
             Condition:
               StringEquals:
-                'aws:principalArn':
-                  !If [
-                    LockCrossAccountPermissionsToLambdaRoles,
-                    'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role',
-                    '*'
-                  ]
+                'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
+          # Otherwise allow anything in the dev query results account root account
+          - Sid: Enable Decrypt access for Query Results dev account
+            Effect: Allow
+            Principal:
+              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+            Action:
+              - kms:Decrypt
+            Resource: '*'
           - Sid: Allow AWS Lambda access
             Effect: Allow
             Principal:
@@ -444,8 +450,10 @@ Resources:
       Queues:
         - !Ref QueryCompletedQueue
       PolicyDocument:
-        Statement:
-          - Sid: AllowResultsDeliveryQueueRead
+        Statement: !If
+          - LockCrossAccountPermissionsToLambdaRoles
+          # If we are in a non-dev environment so know the lambda role name
+          - Sid: AllowResultsDeliveryQueueReadForLambdaRole
             Action:
               - 'sqs:ChangeMessageVisibility'
               - 'sqs:DeleteMessage'
@@ -457,12 +465,18 @@ Resources:
               AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
             Condition:
               StringEquals:
-                'aws:principalArn':
-                  !If [
-                    LockCrossAccountPermissionsToLambdaRoles,
-                    'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role',
-                    '*'
-                  ]
+                'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
+          # Otherwise allow anything in the dev query results account root account
+          - Sid: AllowResultsDeliveryQueueReadForResultsAccount
+            Action:
+              - 'sqs:ChangeMessageVisibility'
+              - 'sqs:DeleteMessage'
+              - 'sqs:GetQueueAttributes'
+              - 'sqs:ReceiveMessage'
+            Effect: 'Allow'
+            Resource: !GetAtt QueryCompletedQueue.Arn
+            Principal:
+              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
 
   QueryCompletedDeadLetterQueue:
     Type: AWS::SQS::Queue

--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -394,10 +394,10 @@ Resources:
             Action:
               - kms:*
             Resource: '*'
-          - Sid: Enable Decrypt access for Query Results account
+          - Sid: Enable Decrypt access for Query Results account generate download Lambda
             Effect: Allow
             Principal:
-              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+              AWS: !Sub 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-build-generate-download-role'
             Action:
               - kms:Decrypt
             Resource: '*'
@@ -443,7 +443,7 @@ Resources:
             Resource: !GetAtt QueryCompletedQueue.Arn
             Principal:
               AWS:
-                - '{{resolve:ssm:QueryResultsAccountRootArn}}'
+                - !Sub 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-build-generate-download-role'
 
   QueryCompletedDeadLetterQueue:
     Type: AWS::SQS::Queue

--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -423,7 +423,7 @@ Resources:
       QueueName: !Sub ${AWS::StackName}-${Environment}-query-completed-queue
       KmsMasterKeyId: !GetAtt QueryCompletedQueueKmsKey.Arn
       RedrivePolicy:
-        deadLetterTargetArn: !GetAtt AuditDataRequestEventsDeadLetterQueue.Arn
+        deadLetterTargetArn: !GetAtt QueryCompletedDeadLetterQueue.Arn
         maxReceiveCount: 5
 
   QueryCompletedQueuePolicy:

--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -399,26 +399,26 @@ Resources:
               - kms:*
             Resource: '*'
           - !If
-          - LockCrossAccountPermissionsToLambdaRoles
-          # If we are in a non-dev environment so know the lambda role name
-          - Sid: Enable Decrypt access for Query Results account generate download Lambda
-            Effect: Allow
-            Principal:
-              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
-            Action:
-              - kms:Decrypt
-            Resource: '*'
-            Condition:
-              StringEquals:
-                'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
-          # Otherwise allow anything in the dev query results account root account
-          - Sid: Enable Decrypt access for Query Results dev account
-            Effect: Allow
-            Principal:
-              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
-            Action:
-              - kms:Decrypt
-            Resource: '*'
+            - LockCrossAccountPermissionsToLambdaRoles
+            # If we are in a non-dev environment so know the lambda role name
+            - Sid: Enable Decrypt access for Query Results account generate download Lambda
+              Effect: Allow
+              Principal:
+                AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+              Action:
+                - kms:Decrypt
+              Resource: '*'
+              Condition:
+                StringEquals:
+                  'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
+            # Otherwise allow anything in the dev query results account root account
+            - Sid: Enable Decrypt access for Query Results dev account
+              Effect: Allow
+              Principal:
+                AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+              Action:
+                - kms:Decrypt
+              Resource: '*'
           - Sid: Allow AWS Lambda access
             Effect: Allow
             Principal:
@@ -450,33 +450,34 @@ Resources:
       Queues:
         - !Ref QueryCompletedQueue
       PolicyDocument:
-        Statement: !If
-          - LockCrossAccountPermissionsToLambdaRoles
-          # If we are in a non-dev environment so know the lambda role name
-          - Sid: AllowResultsDeliveryQueueReadForLambdaRole
-            Action:
-              - 'sqs:ChangeMessageVisibility'
-              - 'sqs:DeleteMessage'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:ReceiveMessage'
-            Effect: 'Allow'
-            Resource: !GetAtt QueryCompletedQueue.Arn
-            Principal:
-              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
-            Condition:
-              StringEquals:
-                'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
-          # Otherwise allow anything in the dev query results account root account
-          - Sid: AllowResultsDeliveryQueueReadForResultsAccount
-            Action:
-              - 'sqs:ChangeMessageVisibility'
-              - 'sqs:DeleteMessage'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:ReceiveMessage'
-            Effect: 'Allow'
-            Resource: !GetAtt QueryCompletedQueue.Arn
-            Principal:
-              AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+        Statement:
+          - !If
+            - LockCrossAccountPermissionsToLambdaRoles
+            # If we are in a non-dev environment so know the lambda role name
+            - Sid: AllowResultsDeliveryQueueReadForLambdaRole
+              Action:
+                - 'sqs:ChangeMessageVisibility'
+                - 'sqs:DeleteMessage'
+                - 'sqs:GetQueueAttributes'
+                - 'sqs:ReceiveMessage'
+              Effect: 'Allow'
+              Resource: !GetAtt QueryCompletedQueue.Arn
+              Principal:
+                AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
+              Condition:
+                StringEquals:
+                  'aws:principalArn': 'arn:aws:iam::{{resolve:ssm:QueryResultsAccountNumber}}:role/txma-query-results-${Environment}-generate-download-role'
+            # Otherwise allow anything in the dev query results account root account
+            - Sid: AllowResultsDeliveryQueueReadForResultsAccount
+              Action:
+                - 'sqs:ChangeMessageVisibility'
+                - 'sqs:DeleteMessage'
+                - 'sqs:GetQueueAttributes'
+                - 'sqs:ReceiveMessage'
+              Effect: 'Allow'
+              Resource: !GetAtt QueryCompletedQueue.Arn
+              Principal:
+                AWS: '{{resolve:ssm:QueryResultsAccountRootArn}}'
 
   QueryCompletedDeadLetterQueue:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
We've now got a specific role in the results-delivery account for the lambda that needs to consume the QueryCompleteQueue, so we can now lock down the queue policy and KMS key to only allow that role to access it.