### PR TITLE
Increase MessageRetentionPeriod for audit queues

### DIFF
--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -16,6 +16,7 @@ Parameters:
 Conditions:
   LockCrossAccountPermissionsToLambdaRoles:
     !Not [!Equals [!Ref Environment, dev]]
+  IsProduction: !Equals [!Ref Environment, 'production']
 
 Resources:
   BatchJobManifestBucket:
@@ -354,6 +355,9 @@ Resources:
   AuditDataRequestEventsQueue:
     Type: AWS::SQS::Queue
     Properties:
+      # We've been asked to use a message retention period of 14 days in production to allow ample time for integration
+      # Elswhere, to save wasted queue entries, we use two hours
+      MessageRetentionPeriod: !If [IsProduction, 1209600, 7200]
       QueueName: !Sub ${AWS::StackName}-${Environment}-audit-data-request-events-queue
       KmsMasterKeyId: !GetAtt AuditDataRequestEventsQueueKmsKey.Arn
       RedrivePolicy:

--- a/query-results/template.yaml
+++ b/query-results/template.yaml
@@ -15,6 +15,7 @@ Parameters:
 Conditions:
   LockCrossAccountPermissionsToLambdaRoles:
     !Not [!Equals [!Ref Environment, dev]]
+  IsProduction: !Equals [!Ref Environment, production]
 
 Resources:
   QueryResultsBucket:
@@ -177,6 +178,9 @@ Resources:
   AuditDataRequestEventsQueue:
     Type: AWS::SQS::Queue
     Properties:
+      # We've been asked to use a message retention period of 14 days in production to allow ample time for integration
+      # Elswhere, to save wasted queue entries, we use two hours
+      MessageRetentionPeriod: !If [IsProduction, 1209600, 7200]
       QueueName: !Sub ${AWS::StackName}-${Environment}-audit-data-request-events-queue
       KmsMasterKeyId: !GetAtt AuditDataRequestEventsQueueKmsKey.Arn
       RedrivePolicy:


### PR DESCRIPTION
To allow time for integration by TxMA1, we're increasing the amount of time queue messages will remain in the audit queues