### PR TITLE
Specify ZendeskId in test data setup message

### DIFF
--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.spec.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.spec.ts
@@ -1,7 +1,8 @@
 import { constructSqsEvent } from '../../utils/tests/constructSqsEvent'
 import {
   TEST_ATHENA_QUERY_ID,
-  TEST_FILE_CONTENTS
+  TEST_FILE_CONTENTS,
+  TEST_ZENDESK_ID
 } from '../../utils/tests/testConstants'
 import { handler } from './handler'
 import { writeTestFileToAthenaOutputBucket } from './writeTestFileToAthenaOutputBucket'
@@ -31,7 +32,8 @@ describe('writeTestDataToAthenaBucket handler', () => {
     const writeTestDataToAthenaBucketEvent = constructSqsEvent(
       JSON.stringify({
         athenaQueryId: TEST_ATHENA_QUERY_ID,
-        fileContents: TEST_FILE_CONTENTS
+        fileContents: TEST_FILE_CONTENTS,
+        zendeskId: TEST_ZENDESK_ID
       })
     )
 
@@ -43,7 +45,8 @@ describe('writeTestDataToAthenaBucket handler', () => {
     )
 
     expect(sendQueryCompletedQueueMessage).toHaveBeenCalledWith(
-      TEST_ATHENA_QUERY_ID
+      TEST_ATHENA_QUERY_ID,
+      TEST_ZENDESK_ID
     )
   })
 })

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.ts
@@ -15,7 +15,10 @@ export const handler = async (event: SQSEvent) => {
     eventDetails.fileContents
   )
 
-  await sendQueryCompletedQueueMessage(eventDetails.athenaQueryId)
+  await sendQueryCompletedQueueMessage(
+    eventDetails.athenaQueryId,
+    eventDetails.zendeskId
+  )
   return eventDetails
 }
 
@@ -30,9 +33,13 @@ const parseRequestDetails = (event: SQSEvent) => {
   }
 
   const requestDetails = tryParseJSON(eventBody)
-  if (!requestDetails.athenaQueryId || !requestDetails.fileContents) {
+  if (
+    !requestDetails.athenaQueryId ||
+    !requestDetails.fileContents ||
+    !requestDetails.zendeskId
+  ) {
     throw Error(
-      'Event data was not of the correct type, should have athenaQueryId and fileContents properties'
+      'Event data was not of the correct type, should have athenaQueryId, fileContents and zendeskId properties'
     )
   }
 

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.spec.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.spec.ts
@@ -5,7 +5,8 @@ import 'aws-sdk-client-mock-jest'
 import {
   TEST_QUERY_COMPLETED_QUEUE_URL,
   TEST_ATHENA_QUERY_ID,
-  TEST_MESSAGE_ID
+  TEST_MESSAGE_ID,
+  TEST_ZENDESK_ID
 } from '../../utils/tests/testConstants'
 
 const sqsMock = mockClient(SQSClient)
@@ -14,7 +15,10 @@ describe('sendQueryCompletedQueueMessage', () => {
   it('sends message to correct queue with correct details', async () => {
     sqsMock.on(SendMessageCommand).resolves({ MessageId: TEST_MESSAGE_ID })
 
-    const messageId = await sendQueryCompletedQueueMessage(TEST_ATHENA_QUERY_ID)
+    const messageId = await sendQueryCompletedQueueMessage(
+      TEST_ATHENA_QUERY_ID,
+      TEST_ZENDESK_ID
+    )
     expect(messageId).toEqual(TEST_MESSAGE_ID)
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
       QueueUrl: TEST_QUERY_COMPLETED_QUEUE_URL,
@@ -22,7 +26,7 @@ describe('sendQueryCompletedQueueMessage', () => {
         athenaQueryId: TEST_ATHENA_QUERY_ID,
         recipientEmail: 'mytestrecipientemail@test.gov.uk',
         recipientName: 'Query Results Test Name',
-        zendeskTicketId: '123'
+        zendeskTicketId: TEST_ZENDESK_ID
       })
     })
   })

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.ts
@@ -7,7 +7,8 @@ import {
 import { getEnv } from '../../utils/getEnv'
 
 export const sendQueryCompletedQueueMessage = async (
-  athenaQueryId: string
+  athenaQueryId: string,
+  zendeskId: string
 ): Promise<string | undefined> => {
   const client = new SQSClient({ region: getEnv('AWS_REGION') })
   const message: SendMessageRequest = {
@@ -16,7 +17,7 @@ export const sendQueryCompletedQueueMessage = async (
       athenaQueryId: athenaQueryId,
       recipientEmail: 'mytestrecipientemail@test.gov.uk',
       recipientName: 'Query Results Test Name',
-      zendeskTicketId: '123'
+      zendeskTicketId: zendeskId
     })
   }
   const result = await client.send(new SendMessageCommand(message))

--- a/audit-test-tools/src/utils/tests/testConstants.ts
+++ b/audit-test-tools/src/utils/tests/testConstants.ts
@@ -4,3 +4,4 @@ export const TEST_FILE_CONTENTS = 'myContents,moreContents'
 export const TEST_MESSAGE_ID = 'myTestMessageId'
 export const TEST_QUERY_COMPLETED_QUEUE_URL =
   'https://my-query-completed-queue-url'
+export const TEST_ZENDESK_ID = '123'


### PR DESCRIPTION
The queue we're using to allow query-results to set up test data needs to be able to use a zendeskId to find the record in the secure download database when it's created.

The previous version of this code hard-coded this id, which meant that the test code in results-delivery wouldn't have been able to find it