### PR TITLE
Add recipient email as a parameter for audit test lambda

### DIFF
--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.spec.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.spec.ts
@@ -1,6 +1,7 @@
 import { constructSqsEvent } from '../../utils/tests/constructSqsEvent'
 import {
   TEST_ATHENA_QUERY_ID,
+  TEST_EMAIL_ADDRESS,
   TEST_FILE_CONTENTS,
   TEST_ZENDESK_ID
 } from '../../utils/tests/testConstants'
@@ -33,7 +34,8 @@ describe('writeTestDataToAthenaBucket handler', () => {
       JSON.stringify({
         athenaQueryId: TEST_ATHENA_QUERY_ID,
         fileContents: TEST_FILE_CONTENTS,
-        zendeskId: TEST_ZENDESK_ID
+        zendeskId: TEST_ZENDESK_ID,
+        recipientEmail: TEST_EMAIL_ADDRESS
       })
     )
 
@@ -46,7 +48,8 @@ describe('writeTestDataToAthenaBucket handler', () => {
 
     expect(sendQueryCompletedQueueMessage).toHaveBeenCalledWith(
       TEST_ATHENA_QUERY_ID,
-      TEST_ZENDESK_ID
+      TEST_ZENDESK_ID,
+      TEST_EMAIL_ADDRESS
     )
   })
 })

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/handler.ts
@@ -17,7 +17,8 @@ export const handler = async (event: SQSEvent) => {
 
   await sendQueryCompletedQueueMessage(
     eventDetails.athenaQueryId,
-    eventDetails.zendeskId
+    eventDetails.zendeskId,
+    eventDetails.recipientEmail
   )
   return eventDetails
 }
@@ -36,10 +37,11 @@ const parseRequestDetails = (event: SQSEvent) => {
   if (
     !requestDetails.athenaQueryId ||
     !requestDetails.fileContents ||
-    !requestDetails.zendeskId
+    !requestDetails.zendeskId ||
+    !requestDetails.recipientEmail
   ) {
     throw Error(
-      'Event data was not of the correct type, should have athenaQueryId, fileContents and zendeskId properties'
+      'Event data was not of the correct type, should have athenaQueryId, fileContents, recipientEmail and zendeskId properties'
     )
   }
 

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.spec.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.spec.ts
@@ -6,7 +6,8 @@ import {
   TEST_QUERY_COMPLETED_QUEUE_URL,
   TEST_ATHENA_QUERY_ID,
   TEST_MESSAGE_ID,
-  TEST_ZENDESK_ID
+  TEST_ZENDESK_ID,
+  TEST_EMAIL_ADDRESS
 } from '../../utils/tests/testConstants'
 
 const sqsMock = mockClient(SQSClient)
@@ -17,14 +18,15 @@ describe('sendQueryCompletedQueueMessage', () => {
 
     const messageId = await sendQueryCompletedQueueMessage(
       TEST_ATHENA_QUERY_ID,
-      TEST_ZENDESK_ID
+      TEST_ZENDESK_ID,
+      TEST_EMAIL_ADDRESS
     )
     expect(messageId).toEqual(TEST_MESSAGE_ID)
     expect(sqsMock).toHaveReceivedCommandWith(SendMessageCommand, {
       QueueUrl: TEST_QUERY_COMPLETED_QUEUE_URL,
       MessageBody: JSON.stringify({
         athenaQueryId: TEST_ATHENA_QUERY_ID,
-        recipientEmail: 'mytestrecipientemail@test.gov.uk',
+        recipientEmail: TEST_EMAIL_ADDRESS,
         recipientName: 'Query Results Test Name',
         zendeskTicketId: TEST_ZENDESK_ID
       })

--- a/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.ts
+++ b/audit-test-tools/src/lambdas/writeTestDataToAthenaBucket/sendQueryCompletedQueueMessage.ts
@@ -8,14 +8,15 @@ import { getEnv } from '../../utils/getEnv'
 
 export const sendQueryCompletedQueueMessage = async (
   athenaQueryId: string,
-  zendeskId: string
+  zendeskId: string,
+  recipientEmail: string
 ): Promise<string | undefined> => {
   const client = new SQSClient({ region: getEnv('AWS_REGION') })
   const message: SendMessageRequest = {
     QueueUrl: getEnv('QUERY_COMPLETED_QUEUE_URL'),
     MessageBody: JSON.stringify({
       athenaQueryId: athenaQueryId,
-      recipientEmail: 'mytestrecipientemail@test.gov.uk',
+      recipientEmail: recipientEmail,
       recipientName: 'Query Results Test Name',
       zendeskTicketId: zendeskId
     })

--- a/audit-test-tools/src/utils/tests/testConstants.ts
+++ b/audit-test-tools/src/utils/tests/testConstants.ts
@@ -5,3 +5,4 @@ export const TEST_MESSAGE_ID = 'myTestMessageId'
 export const TEST_QUERY_COMPLETED_QUEUE_URL =
   'https://my-query-completed-queue-url'
 export const TEST_ZENDESK_ID = '123'
+export const TEST_EMAIL_ADDRESS = 'test@test.gov.uk'


### PR DESCRIPTION
We need to be able to specify the recipient email address when triggering the query completed queue during an integration test