### PR TITLE
Enable logging for WAFs

### DIFF
--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -277,6 +277,7 @@ Resources:
     Properties:
       DefaultAction:
         Allow: {}
+      Name: ZendeskWebhookApiWafAcl
       Scope: REGIONAL
       VisibilityConfig:
         CloudWatchMetricsEnabled: true
@@ -320,6 +321,22 @@ Resources:
             CloudWatchMetricsEnabled: true
             MetricName: ZendeskWebhookApiWafIpReputationListMetric
             SampledRequestsEnabled: true
+
+  ZendeskWebhookApiWafLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
+      LogGroupName: aws-waf-logs-ZendeskWebhookApiWafAcl
+      RetentionInDays: 30
+
+  ZendeskWebhookApiWafLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      LogDestinationConfigs:
+        # Cannot use Fn::GetAtt here since the ARN of a log group includes ':*' at the end, which is not accepted by the WAF service.
+        # The ARN must not include the ':*'.
+        - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${ZendeskWebhookApiWafLogs}
+      ResourceArn: !GetAtt ZendeskWebhookApiWafAcl.Arn
 
   # Need a separate KMS key here for the audit queue because we need to grant access to the event processing account
   # and our main KMS key definitions are in 'core', which is a shared set of definitions across all stacks.

--- a/query-results/template.yaml
+++ b/query-results/template.yaml
@@ -120,6 +120,7 @@ Resources:
     Type: AWS::WAFv2::WebACL
     Properties:
       DefaultAction: !If [NotTestEnvironment, Block: {}, Allow: {}]
+      Name: SecureFraudApiWafAcl
       Scope: REGIONAL
       VisibilityConfig:
         CloudWatchMetricsEnabled: true
@@ -177,6 +178,22 @@ Resources:
               MetricName: SecureFraudSiteIpRestrictionMetric
               SampledRequestsEnabled: true
           - !Ref AWS::NoValue
+
+  SecureFraudApiWafLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
+      LogGroupName: aws-waf-logs-SecureFraudApiWafAcl
+      RetentionInDays: 30
+
+  SecureFraudApiWafLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      LogDestinationConfigs:
+        # Cannot use Fn::GetAtt here since the ARN of a log group includes ':*' at the end, which is not accepted by the WAF service.
+        # The ARN must not include the ':*'.
+        - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SecureFraudApiWafLogs}
+      ResourceArn: !GetAtt SecureFraudApiWafAcl.Arn
 
   # Need a separate KMS key here for the audit queue because we need to grant access to the event processing account
   # and our main KMS key definitions are in 'core', which is a shared set of definitions across all stacks.


### PR DESCRIPTION
* Log groups have to be prefixed with 'aws-waf-logs-'
* Logging configuration destination could not use !GetAtt for the ARN since the ARN of a log group includes a `:*` at the end. It seems WAF wants the ARN without this.