### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: dependabot
+      include: scope

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,10 @@ updates:
     commit-message:
       prefix: dependabot
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: npm
     directory: /audit-test-tools
     schedule:
@@ -14,6 +18,10 @@ updates:
     commit-message:
       prefix: dependabot
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
   - package-ecosystem: npm
     directory: /dev-tools
     schedule:
@@ -21,3 +29,7 @@ updates:
     commit-message:
       prefix: dependabot
       include: scope
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,17 @@ updates:
     commit-message:
       prefix: dependabot
       include: scope
+  - package-ecosystem: npm
+    directory: /audit-test-tools
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: dependabot
+      include: scope
+  - package-ecosystem: npm
+    directory: /dev-tools
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: dependabot
+      include: scope


### PR DESCRIPTION
* Run dependabot scan daily and prefix PR titles with "dependabot: "
* Note: package-ecosystem: npm also applies to Yarn - see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem