### PR TITLE
Add GSI for new transferToAnalysisBucketJobId field

### DIFF
--- a/data-analysis/template.yaml
+++ b/data-analysis/template.yaml
@@ -227,6 +227,8 @@ Resources:
           AttributeType: S
         - AttributeName: athenaQueryId
           AttributeType: S
+        - AttributeName: transferToAnalysisBucketJobId
+          AttributeType: S
       KeySchema:
         - AttributeName: zendeskId
           KeyType: HASH
@@ -234,6 +236,15 @@ Resources:
         - IndexName: athenaQueryIdIndex
           KeySchema:
             - AttributeName: athenaQueryId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 5
+            WriteCapacityUnits: 5
+        - IndexName: transferToAnalysisBucketJobIdIndex
+          KeySchema:
+            - AttributeName: transferToAnalysisBucketJobId
               KeyType: HASH
           Projection:
             ProjectionType: ALL


### PR DESCRIPTION
As part of the work to make the error handling for decrypt during data transfer more robust, we need to add the batch job id to the database, and query by it. This new Global Secondary Index will allow us to do the query.

When this value is set, code in the ticf-integration stack will be able to find the relevant record using this index.