### PR TITLE
Add Cognito resources to shared-signals shared infra

### DIFF
--- a/shared-signals/template.yaml
+++ b/shared-signals/template.yaml
@@ -63,6 +63,21 @@ Resources:
         SSEType: KMS
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
 
+  ####################
+  # Cognito Resources
+  ####################
+
+  SSFUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: !Sub ${AWS::StackName}-ssf-user-pool
+
+  SSFUserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Properties:
+      UserPoolId: !Ref SSFUserPool
+      Domain: !Sub di-txma-${AWS::StackName}-${Environment}-ssf-auth
+
   ################
   # SSM Parameters
   ################
@@ -73,3 +88,17 @@ Resources:
       Name: UserConfigTableArn
       Type: String
       Value: !GetAtt UserConfigTable.Arn
+
+  SSFUserPoolIdParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: SSFUserPoolId
+      Type: String
+      Value: !Ref SSFUserPool
+
+  SSFUserPoolArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: SSFUserPoolArn
+      Type: String
+      Value: !GetAtt SSFUserPool.Arn


### PR DESCRIPTION
We realised we don't need a Cognito user pool per stack, so this PR adds a shared one. The resource server is more tied to specifics of what we might do in the stack, so we'll leave that in there for now.