### PR TITLE
Add shared Cognito resource server

### DIFF
--- a/shared-signals/template.yaml
+++ b/shared-signals/template.yaml
@@ -78,6 +78,16 @@ Resources:
       UserPoolId: !Ref SSFUserPool
       Domain: !Sub di-txma-${AWS::StackName}-${Environment}-ssf-auth
 
+  SharedSignalsStreamResourceServer:
+    Type: AWS::Cognito::UserPoolResourceServer
+    Properties:
+      UserPoolId: !Ref SSFUserPool
+      Identifier: 'stream'
+      Name: !Sub '${AWS::StackName}-stream-resource-server'
+      Scopes:
+        - ScopeDescription: 'Allows read access to the SSF stream config'
+          ScopeName: 'read'
+
   ################
   # SSM Parameters
   ################


### PR DESCRIPTION
The use of a resource cognito user pool but stack-specific resource server was causing some issues, and we realised we didn't need one per stack anyway, so this PR adds the only one we need for now.