### PR TITLE
Chore/add s3 file read lambda

### DIFF
--- a/dev-tools/src/lambdas/readS3FileToString/handler.spec.ts
+++ b/dev-tools/src/lambdas/readS3FileToString/handler.spec.ts
@@ -1,0 +1,35 @@
+import { when } from 'jest-when'
+import { S3FileDetails } from '../../types/s3FileDetails'
+import { mockLambdaContext } from '../../utils/tests/mocks/mockLambdaContext'
+import { handler } from './handler'
+import { s3DownloadFileToString } from './s3DownloadFileToString'
+
+jest.mock('./s3DownloadFileToString', () => ({
+  s3DownloadFileToString: jest.fn()
+}))
+
+describe('Read s3 file to string handler', () => {
+  it('returns error with invalid parameters', async () => {
+    expect(
+      handler(
+        { invalid: 'test' } as unknown as S3FileDetails,
+        mockLambdaContext
+      )
+    ).rejects.toThrow('Function called with invalid parameters')
+  })
+
+  it('Passes the correct data to s3DownloadFileToString', async () => {
+    const testBucketName = 'myBucketName'
+    const testFileKey = 'myFileKey'
+    const testFileContents = 'my file contents'
+    when(s3DownloadFileToString).mockResolvedValue(testFileContents)
+
+    const result = await handler(
+      { bucketName: testBucketName, key: testFileKey },
+      mockLambdaContext
+    )
+
+    expect(result).toEqual(testFileContents)
+    expect(s3DownloadFileToString).toBeCalledWith(testBucketName, testFileKey)
+  })
+})

--- a/dev-tools/src/lambdas/readS3FileToString/handler.ts
+++ b/dev-tools/src/lambdas/readS3FileToString/handler.ts
@@ -1,0 +1,19 @@
+import { Context } from 'aws-lambda'
+import { S3FileDetails } from '../../types/s3FileDetails'
+import { initialiseLogger, logger } from '../../utils/logger'
+import { s3DownloadFileToString } from './s3DownloadFileToString'
+
+export const handler = async (
+  params: S3FileDetails,
+  context: Context
+): Promise<string | undefined> => {
+  initialiseLogger(context)
+  if (!params?.bucketName || !params?.key)
+    throw Error('Function called with invalid parameters')
+
+  logger.info('Reading file', {
+    bucketName: params.bucketName,
+    key: params.key
+  })
+  return s3DownloadFileToString(params.bucketName, params.key)
+}

--- a/dev-tools/src/lambdas/readS3FileToString/s3DownloadFileToString.spec.ts
+++ b/dev-tools/src/lambdas/readS3FileToString/s3DownloadFileToString.spec.ts
@@ -1,0 +1,60 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { mockClient } from 'aws-sdk-client-mock'
+
+import 'aws-sdk-client-mock-jest'
+import { Readable } from 'stream'
+import { s3DownloadFileToString } from './s3DownloadFileToString'
+
+const s3Mock = mockClient(S3Client)
+const testS3Data = 'some data'
+
+const createDataStream = () => {
+  const dataStream = new Readable()
+  dataStream.push(testS3Data)
+  dataStream.push(null)
+  return dataStream
+}
+
+const givenDataIsAvailable = () => {
+  s3Mock.on(GetObjectCommand).resolves({ Body: createDataStream() })
+}
+
+const givenFileDoesNotExist = () => {
+  s3Mock.on(GetObjectCommand).rejects({ name: 'NoSuchKey' })
+}
+
+const givenGenericErrorDownloadingFile = () => {
+  s3Mock.on(GetObjectCommand).rejects({ name: 'SomeOtherError' })
+}
+
+describe('readS3DataToString', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const testBucket = 'myTestBucket'
+  const testKey = 'myTestKey'
+
+  it('returns a string read from the file', async () => {
+    givenDataIsAvailable()
+
+    const returnedData = await s3DownloadFileToString(testBucket, testKey)
+
+    expect(s3Mock).toHaveReceivedCommandWith(GetObjectCommand, {
+      Bucket: testBucket,
+      Key: testKey
+    })
+    expect(returnedData).toEqual(testS3Data)
+  })
+
+  it('returns undefined if the file is not found', async () => {
+    givenFileDoesNotExist()
+    const returnedData = await s3DownloadFileToString(testBucket, testKey)
+    expect(returnedData).toBeUndefined()
+  })
+
+  it('throws if there is another error downloading the data', async () => {
+    givenGenericErrorDownloadingFile()
+    expect(s3DownloadFileToString(testBucket, testKey)).rejects.toThrow()
+  })
+})

--- a/dev-tools/src/lambdas/readS3FileToString/s3DownloadFileToString.ts
+++ b/dev-tools/src/lambdas/readS3FileToString/s3DownloadFileToString.ts
@@ -1,0 +1,26 @@
+import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import { Readable } from 'stream'
+import consumers from 'stream/consumers'
+import { logger } from '../../utils/logger'
+
+export const s3DownloadFileToString = async (
+  bucketName: string,
+  fileKey: string
+): Promise<string | undefined> => {
+  const commandInput = {
+    Bucket: bucketName,
+    Key: fileKey
+  }
+  logger.info(`Trying to read file ${fileKey} in bucket ${bucketName}`)
+  const s3Client = new S3Client({ region: process.env['AWS_REGION'] })
+  try {
+    const { Body } = await s3Client.send(new GetObjectCommand(commandInput))
+    return consumers.text(Body as Readable)
+  } catch (error) {
+    const notFoundError = error as { name: string }
+    if (notFoundError && notFoundError.name === 'NoSuchKey') {
+      return undefined
+    }
+    throw error
+  }
+}

--- a/dev-tools/src/types/s3FileDetails.ts
+++ b/dev-tools/src/types/s3FileDetails.ts
@@ -1,0 +1,4 @@
+export interface S3FileDetails {
+  bucketName: string
+  key: string
+}

--- a/dev-tools/template.yaml
+++ b/dev-tools/template.yaml
@@ -66,7 +66,7 @@ Resources:
 
   ReadS3FileToStringFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals section
-    #checkov:skip=CKV_AWS_116:Lambda is behind an API gateway, so repeated processing of the same message isn't a problem
+    #checkov:skip=CKV_AWS_116:Lambda will be called by integration test, so repeated processing of the same message isn't a problem
     #checkov:skip=CKV_AWS_117:VPC not required
     Type: AWS::Serverless::Function
     Properties:

--- a/dev-tools/template.yaml
+++ b/dev-tools/template.yaml
@@ -64,6 +64,31 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}-add-firehose-record
       RetentionInDays: 30
 
+  ReadS3FileToStringFunction:
+    #checkov:skip=CKV_AWS_115:Defined in Globals section
+    #checkov:skip=CKV_AWS_116:Lambda is behind an API gateway, so repeated processing of the same message isn't a problem
+    #checkov:skip=CKV_AWS_117:VPC not required
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: readS3FileToString.handler
+      FunctionName: !Sub ${AWS::StackName}-read-s3-file
+      KmsKeyArn: '{{resolve:ssm:LambdaKmsKeyArn}}'
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject*
+                # Adding the ListBucket permission ensures that when a file doesn't exist, we get a 404 instead of a 403
+                - s3:ListBucket
+              Resource: '*'
+
+  ReadS3FileToStringLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      KmsKeyId: '{{resolve:ssm:LogsKmsKeyArn}}'
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}-read-s3-file
+      RetentionInDays: 30
+
   EmptyS3BucketsFunction:
     #checkov:skip=CKV_AWS_115:Defined in Globals
     #checkov:skip=CKV_AWS_116:DLQ not required as failures will be reported to CloudFormation


### PR DESCRIPTION
For some updated integration tests in ticf-integration, we realise it will be useful to have a Lambda that can read data from S3 buckets on behalf of the test role, which will stop us having to define bucket policies across multiple stacks.