### PR TITLE
Add Firehose KMS key and Alerts SNS topic to core infra

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -21,9 +21,9 @@ Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, none]]
 
 Resources:
-  #############
-  # AWS Chatbot
-  #############
+  #################################
+  # Start: Slack Alerts resources #
+  #################################
 
   ChatbotAlarmRole:
     Type: AWS::IAM::Role
@@ -44,9 +44,38 @@ Resources:
             Action:
               - 'sts:AssumeRole'
 
-  ##########
-  # KMS Keys
-  ##########
+  SNSCriticalAlarmTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      KmsMasterKeyId: !GetAtt SnsKmsKey.Arn
+      TopicName: !Sub ${AWS::StackName}-${Environment}-critical-alarm-topic
+
+  SNSCriticalAlarmTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Action: 'sns:Publish'
+            Resource: !GetAtt SNSCriticalAlarmTopic.TopicArn
+            Condition:
+              ArnLike:
+                aws:SourceArn: !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:*
+              StringEquals:
+                aws:SourceAccount: !Sub ${AWS::AccountId}
+      Topics:
+        - !Ref SNSCriticalAlarmTopic
+
+  ###############################
+  # End: Slack Alerts resources #
+  ###############################
+
+  ###################
+  # Start: KMS Keys #
+  ###################
 
   DatabaseKmsKey:
     Type: AWS::KMS::Key
@@ -75,6 +104,36 @@ Resources:
     Properties:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/database-kms-key
       TargetKeyId: !Ref DatabaseKmsKey
+
+  FirehoseKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - kms:*
+            Resource:
+              - '*'
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: '*'
+
+  FirehoseKmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub 'alias/${AWS::StackName}/${Environment}/firehose-kms-key'
+      TargetKeyId: !Ref FirehoseKmsKey
 
   LambdaKmsKey:
     Type: AWS::KMS::Key
@@ -242,9 +301,13 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/queue-kms-key
       TargetKeyId: !Ref SqsKmsKey
 
-  #########
-  # S3 Logs
-  #########
+  #################
+  # End: KMS Keys #
+  #################
+
+  ############################
+  # Start: S3 Logs resources #
+  ############################
 
   S3LogsBucket:
     #checkov:skip=CKV_AWS_18:This is the logs bucket
@@ -304,9 +367,13 @@ Resources:
               Bool:
                 aws:SecureTransport: true
 
-  ################
-  # SSM Parameters
-  ################
+  ##########################
+  # End: S3 Logs resources #
+  ##########################
+
+  #########################
+  # Start: SSM Parameters #
+  #########################
 
   ChatbotAlarmRoleArnParameter:
     Type: AWS::SSM::Parameter
@@ -315,12 +382,26 @@ Resources:
       Type: String
       Value: !GetAtt ChatbotAlarmRole.Arn
 
+  CriticalAlarmSnsTopicArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: CriticalAlarmSnsTopicArn
+      Type: String
+      Value: !GetAtt SNSCriticalAlarmTopic.Arn
+
   DatabaseKmsKeyArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Name: DatabaseKmsKeyArn
       Type: String
       Value: !GetAtt DatabaseKmsKey.Arn
+
+  FirehoseKmsKeyArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: FirehoseKmsKeyArn
+      Type: String
+      Value: !GetAtt FirehoseKmsKey.Arn
 
   LambdaKmsKeyArnParameter:
     Type: AWS::SSM::Parameter
@@ -363,3 +444,7 @@ Resources:
       Name: CoreSnsKmsKeyArn
       Type: String
       Value: !GetAtt SnsKmsKey.Arn
+
+  #######################
+  # End: SSM Parameters #
+  #######################


### PR DESCRIPTION
- Added Firehose KMS key to core stack so Audit and Event Processing templates can use this instead of defining their own
- Added SNS Topic for alerting to core stack as all accounts now have an alerts stack deployed, and it makes sense to have it here instead of specifically in the audit account/in each account defined separately
- Add CF template linting to core infra pre-merge workflow

Note: Will raise follow up PRs to use this in audit and event processing