### PR TITLE
Allow DynamoDB key attribute name to be specified

### DIFF
--- a/dev-tools/src/lambdas/dynamoOperations/dynamoDbDelete.spec.ts
+++ b/dev-tools/src/lambdas/dynamoOperations/dynamoDbDelete.spec.ts
@@ -14,14 +14,15 @@ describe('dynamoDbDelete', () => {
   const deleteDynamoEntryCommand = {
     TableName: QUERY_REQUEST_DYNAMODB_TABLE_NAME,
     Key: {
-      zendeskId: { S: ZENDESK_TICKET_ID }
+      myKeyAttributeName: { S: ZENDESK_TICKET_ID }
     }
   }
 
   it('dynamo client is called with the correct params', async () => {
     await dynamoDbDelete({
       tableName: QUERY_REQUEST_DYNAMODB_TABLE_NAME,
-      zendeskId: ZENDESK_TICKET_ID
+      keyAttributeName: 'myKeyAttributeName',
+      keyAttributeValue: ZENDESK_TICKET_ID
     })
 
     expect(dynamoMock).toHaveReceivedCommandWith(
@@ -30,9 +31,15 @@ describe('dynamoDbDelete', () => {
     )
   })
 
-  it('throws an error when function is called without a zendeskId', async () => {
-    expect(dynamoDbDelete({} as OperationParams)).rejects.toThrow(
-      'No Zendesk ID found in dynamoDbDelete parameters'
-    )
+  it('throws an error when function is called without a keyAttributeValue', async () => {
+    expect(
+      dynamoDbDelete({ keyAttributeName: 'myKeyName ' } as OperationParams)
+    ).rejects.toThrow('No keyAttributeValue found in dynamoDbDelete parameters')
+  })
+
+  it('throws an error when function is called without a keyAttributeName', async () => {
+    expect(
+      dynamoDbDelete({ keyAttributeValue: 'myKeyValue ' } as OperationParams)
+    ).rejects.toThrow('No keyAttributeName found in dynamoDbDelete parameters')
   })
 })

--- a/dev-tools/src/lambdas/dynamoOperations/dynamoDbDelete.ts
+++ b/dev-tools/src/lambdas/dynamoOperations/dynamoDbDelete.ts
@@ -3,13 +3,17 @@ import { OperationParams } from '../../types/dynamoDbOperation'
 import { dynamoDbClient } from './dynamoDbClient'
 
 export const dynamoDbDelete = async (operationParams: OperationParams) => {
-  if (!operationParams.zendeskId)
-    throw Error('No Zendesk ID found in dynamoDbDelete parameters')
+  if (!operationParams.keyAttributeValue)
+    throw Error('No keyAttributeValue found in dynamoDbDelete parameters')
+  if (!operationParams.keyAttributeName)
+    throw Error('No keyAttributeName found in dynamoDbDelete parameters')
 
   const deleteDynamoEntryCommand = {
     TableName: operationParams.tableName,
     Key: {
-      zendeskId: { S: operationParams.zendeskId }
+      [operationParams.keyAttributeName]: {
+        S: operationParams.keyAttributeValue
+      }
     }
   }
 

--- a/dev-tools/src/lambdas/dynamoOperations/dynamoDbGet.spec.ts
+++ b/dev-tools/src/lambdas/dynamoOperations/dynamoDbGet.spec.ts
@@ -27,7 +27,7 @@ describe('dynamoDbGet', () => {
     return {
       TableName: QUERY_REQUEST_DYNAMODB_TABLE_NAME,
       Key: {
-        zendeskId: { S: ZENDESK_TICKET_ID }
+        myKeyAttributeName: { S: ZENDESK_TICKET_ID }
       },
       ...(attributeName && { ProjectionExpression: attributeName })
     }
@@ -39,7 +39,8 @@ describe('dynamoDbGet', () => {
 
     const dynamoItem = await dynamoDbGet({
       tableName: QUERY_REQUEST_DYNAMODB_TABLE_NAME,
-      zendeskId: ZENDESK_TICKET_ID
+      keyAttributeName: 'myKeyAttributeName',
+      keyAttributeValue: ZENDESK_TICKET_ID
     })
 
     expect(dynamoMock).toHaveReceivedCommandWith(
@@ -56,7 +57,8 @@ describe('dynamoDbGet', () => {
 
     const dynamoItem = await dynamoDbGet({
       tableName: QUERY_REQUEST_DYNAMODB_TABLE_NAME,
-      zendeskId: ZENDESK_TICKET_ID,
+      keyAttributeName: 'myKeyAttributeName',
+      keyAttributeValue: ZENDESK_TICKET_ID,
       attributeName: 'athenaQueryId'
     })
 
@@ -67,9 +69,15 @@ describe('dynamoDbGet', () => {
     expect(dynamoItem).toEqual(MOCK_ITEM)
   })
 
-  it('throws an error when function is called without a zendeskId', async () => {
-    expect(dynamoDbGet({} as OperationParams)).rejects.toThrow(
-      'No Zendesk ID found in dynamoDbGet parameters'
-    )
+  it('throws an error when function is called without a keyAttributeValue', async () => {
+    expect(
+      dynamoDbGet({ keyAttributeName: 'myKeyName ' } as OperationParams)
+    ).rejects.toThrow('No keyAttributeValue found in dynamoDbGet parameters')
+  })
+
+  it('throws an error when function is called without a keyAttributeName', async () => {
+    expect(
+      dynamoDbGet({ keyAttributeValue: 'myKeyValue ' } as OperationParams)
+    ).rejects.toThrow('No keyAttributeName found in dynamoDbGet parameters')
   })
 })

--- a/dev-tools/src/lambdas/dynamoOperations/dynamoDbGet.ts
+++ b/dev-tools/src/lambdas/dynamoOperations/dynamoDbGet.ts
@@ -3,13 +3,17 @@ import { OperationParams } from '../../types/dynamoDbOperation'
 import { dynamoDbClient } from './dynamoDbClient'
 
 export const dynamoDbGet = async (operationParams: OperationParams) => {
-  if (!operationParams.zendeskId)
-    throw Error('No Zendesk ID found in dynamoDbGet parameters')
+  if (!operationParams.keyAttributeValue)
+    throw Error('No keyAttributeValue found in dynamoDbGet parameters')
+  if (!operationParams.keyAttributeName)
+    throw Error('No keyAttributeName found in dynamoDbGet parameters')
 
   const getDynamoEntryCommand = {
     TableName: operationParams.tableName,
     Key: {
-      zendeskId: { S: `${operationParams.zendeskId}` }
+      [operationParams.keyAttributeName]: {
+        S: `${operationParams.keyAttributeValue}`
+      }
     },
     ...(operationParams.attributeName && {
       ProjectionExpression: operationParams.attributeName

--- a/dev-tools/src/lambdas/dynamoOperations/handler.ts
+++ b/dev-tools/src/lambdas/dynamoOperations/handler.ts
@@ -3,7 +3,7 @@ import { DynamoDbOperation } from '../../types/dynamoDbOperation'
 import {
   initialiseLogger,
   logger,
-  appendZendeskIdToLogger
+  appendKeyAttributeDataToLogger
 } from '../../utils/logger'
 import { dynamoDbDelete } from './dynamoDbDelete'
 import { dynamoDbGet } from './dynamoDbGet'
@@ -17,8 +17,14 @@ export const handler = async (
   if (!dynamoOperationParams) {
     throw Error('Function called with undefined params')
   }
-  if (dynamoOperationParams.params.zendeskId) {
-    appendZendeskIdToLogger(dynamoOperationParams.params.zendeskId)
+  if (
+    dynamoOperationParams.params.keyAttributeName &&
+    dynamoOperationParams.params.keyAttributeValue
+  ) {
+    appendKeyAttributeDataToLogger(
+      dynamoOperationParams.params.keyAttributeName,
+      dynamoOperationParams.params.keyAttributeValue
+    )
   }
 
   let result

--- a/dev-tools/src/types/dynamoDbOperation.ts
+++ b/dev-tools/src/types/dynamoDbOperation.ts
@@ -7,7 +7,8 @@ export interface DynamoDbOperation {
 
 export interface OperationParams {
   tableName: string
-  zendeskId?: string
+  keyAttributeName?: string
+  keyAttributeValue?: string
   attributeName?: string
   itemToPut?: Record<string, AttributeValue>
 }

--- a/dev-tools/src/utils/logger.ts
+++ b/dev-tools/src/utils/logger.ts
@@ -13,8 +13,11 @@ export const initialiseLogger = (context: Context) => {
   loggerInstance.removeKeys(['zendeskId'])
 }
 
-export const appendZendeskIdToLogger = (zendeskId: string) => {
-  loggerInstance.appendKeys({ zendeskId })
+export const appendKeyAttributeDataToLogger = (
+  keyAttributeName: string,
+  keyAttributeValue: string
+) => {
+  loggerInstance.appendKeys({ [keyAttributeName]: keyAttributeValue })
 }
 
 export const logger = loggerInstance


### PR DESCRIPTION
The previous incarnation of the DynamoDBOperations Lambda only allowed us to query by a specific field (zendeskId) because that was all it was needed for then. We now need to query by other fields, so this PR allows this. It will be a breaking change for the ticf-integration tests, but we'll fix this as soon as this code is merged.