### PR TITLE
TT2-706/ add an alert for when there is a missing field in the pairwise id info

### DIFF
--- a/rp-events/template.yaml
+++ b/rp-events/template.yaml
@@ -235,6 +235,14 @@ Resources:
       QueueName: !Sub ${AWS::StackName}-${Environment}-rp-events-dead-letter-queue
       KmsMasterKeyId: !GetAtt RPEventsQueueKmsKey.Arn
 
+  InvalidPairwiseInfoQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${AWS::StackName}-${Environment}-invalid-pairwise-info-queue
+      KmsMasterKeyId: '{{resolve:ssm:SqsKmsKeyArn}}'
+      VisibilityTimeout: 60
+      MessageRetentionPeriod: 604800 # 7 Days
+
   ################
   # SSM Parameters
   ################
@@ -294,3 +302,10 @@ Resources:
       Name: RPEventsDeadLetterQueueName
       Type: String
       Value: !Ref RPEventsDeadLetterQueue.QueueName
+
+  InvalidPairwiseInfoQueueUrlParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: InvalidPairwiseInfoQueueUrl
+      Type: String
+      Value: !Ref InvalidPairwiseInfoQueue

--- a/rp-events/template.yaml
+++ b/rp-events/template.yaml
@@ -287,3 +287,10 @@ Resources:
       Name: RPEventsQueueUrl
       Type: String
       Value: !Ref RPEventsQueue
+
+  RPEventsDeadLetterQueueNameParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: RPEventsDeadLetterQueueName
+      Type: String
+      Value: !Ref RPEventsDeadLetterQueue.QueueName

--- a/rp-events/template.yaml
+++ b/rp-events/template.yaml
@@ -296,13 +296,6 @@ Resources:
       Type: String
       Value: !Ref RPEventsQueue
 
-  RPEventsDeadLetterQueueNameParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: RPEventsDeadLetterQueueName
-      Type: String
-      Value: !Ref RPEventsDeadLetterQueue.QueueName
-
   InvalidPairwiseInfoQueueUrlParameter:
     Type: AWS::SSM::Parameter
     Properties:


### PR DESCRIPTION
### This PR adds: 

- A new queue, `InvalidPairwiseInfoQueue`, where information will be sent for events with missing fields in the `PairwiseInfo` object. 
- Sets queue retention to 7 Days
- Puts the queue URL in secrets manager for the `Event Processor` function to access 