### PR TITLE
Add KMS key that allows S3 to send notifications to SQS

### DIFF
--- a/audit/template.yaml
+++ b/audit/template.yaml
@@ -14,6 +14,10 @@ Parameters:
       - production
 
 Resources:
+  ###################
+  # Start: KMS Keys #
+  ###################
+
   AuditFileReadyToEncryptQueueKmsKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
@@ -87,6 +91,14 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/encryption-generator-kms-key
       TargetKeyId: !Ref EncryptionGeneratorKmsKey
 
+  #################
+  # End: KMS Keys #
+  #################
+
+  #########################
+  # Start: SSM Parameters #
+  #########################
+
   AuditFileReadyToEncryptQueueKmsKeyArnParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -100,3 +112,7 @@ Resources:
       Name: S3EncryptionGeneratorKmsKeyArn
       Type: String
       Value: !GetAtt EncryptionGeneratorKmsKey.Arn
+
+  #######################
+  # End: SSM Parameters #
+  #######################

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -198,6 +198,36 @@ Resources:
       AliasName: !Sub alias/${AWS::StackName}/${Environment}/logs-kms-key
       TargetKeyId: !Ref LogsKmsKey
 
+  S3QueueNotificationsKmsKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - kms:*
+            Resource:
+              - '*'
+          - Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey
+            Resource: '*'
+
+  S3QueueNotificationsKmsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub alias/${AWS::StackName}/${Environment}/s3-queue-notifications-kms-key
+      TargetKeyId: !Ref S3QueueNotificationsKmsKey
+
   SecretsKmsKey:
     Type: AWS::KMS::Key
     Properties:
@@ -424,6 +454,13 @@ Resources:
       Name: S3LogsBucketName
       Type: String
       Value: !Ref S3LogsBucket
+
+  S3QueueNotificationsKmsKeyArnParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: S3QueueNotificationsKmsKeyArn
+      Type: String
+      Value: !GetAtt S3QueueNotificationsKmsKey.Arn
 
   SecretsKmsKeyArnParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
For the Audit Firehose failure mechanism, we want a method to trigger a Lambda reingest function when there are messages in a DLQ. Since Firehose does not support a DLQ directly, we want to send notifications to a queue from S3. This KMS key can be used to encrypt the SQS queue, but still allow S3 access