### PR TITLE
allow SNS access to the SQS queue kms key

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -330,6 +330,17 @@ Resources:
               - kms:Encrypt
               - kms:Decrypt
             Resource: '*'
+          - Sid: Allow AWS SNS access
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: '*'
 
   SqsKmsKeyAlias:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
pre-emptive policy update for TT2-779, this should allow the main SNS topic to access the SQS KMS key. This should mean that if SNS fails to deliver a message, it can put the message on the encrypted DLQ. All sqs queues share the same KMS key 