### PR TITLE
fix/swapped billing mode to pay_per_request

### DIFF
--- a/infrastructure/rp-events/template.yaml
+++ b/infrastructure/rp-events/template.yaml
@@ -42,9 +42,7 @@ Resources:
       KeySchema:
         - AttributeName: securityEventName
           KeyType: HASH
-      ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
+      BillingMode: PAY_PER_REQUEST
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
       SSESpecification:


### PR DESCRIPTION
As the `RelyingPartyConfigTable` will be read for every event that comes through, I think having a fixed ProvisionedThroughput will end up throttling read/write requests. I have switched it to `BillingMode: PAY_PER_REQUEST` which matches the other table in this account 