### PR TITLE
adding s3 SQS KMS Key access

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -341,6 +341,14 @@ Resources:
               - kms:GenerateDataKey*
               - kms:Describe*
             Resource: '*'
+          - Sid: Allow AWS S3 access
+            Effect: Allow
+            Principal:
+              Service: s3.amazonaws.com
+            Action:
+              - kms:Decrypt*
+              - kms:GenerateDataKey*
+            Resource: '*'
 
   SqsKmsKeyAlias:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
For my ticket (https://govukverify.atlassian.net/browse/TT2-780), S3 will write PutObject events to an SQS queue which will then be used to trigger a lambda. To do this, S3 needs access to the SQS KMS key according to this guide here https://docs.aws.amazon.com/AmazonS3/latest/userguide/ways-to-add-notification-config-to-bucket.html.