### PR TITLE
Allow any bucket ending with permanent-message-batch to send events

### DIFF
--- a/infrastructure/audit/template.yaml
+++ b/infrastructure/audit/template.yaml
@@ -265,7 +265,7 @@ Resources:
                 - s3.amazonaws.com
             Condition:
               ArnLike:
-                aws:SourceArn: !Sub arn:aws:s3:::audit-${Environment}-permanent-message-batch
+                aws:SourceArn: !Sub arn:aws:s3:::*-permanent-message-batch
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
 


### PR DESCRIPTION
The previous set of changes were too restrictive, and didn't let feature stacks in audit send messages to this queue